### PR TITLE
add vite-plugin-inline-css-modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ _more coming soon..._
 - [Babel Solid Plugin - Understrcuture](https://github.com/orenelbaum/babel-plugin-solid-undestructure) - Destructure component props without losing reactivity
 - [Solid SFC(Experimental)](https://github.com/LXSMNSYC/solid-sfc) - Experimental SFC compiler for SolidJS
 - [Solid Styled](https://github.com/LXSMNSYC/solid-styled) - Reactive stylesheets for SolidJS
+- [vite-plugin-inline-css-modules](https://github.com/Bluskript/vite-plugin-inline-css-modules) - Zero runtime plugin to write CSS modules inside of component files
 
 ### SSR
 - [Solid Start](https://github.com/solidjs/solid-start) - Official meta framework for SolidJS


### PR DESCRIPTION
Although not exclusive to Solid, I still think this is a valuable tool that improves the DX of writing Solid components. Seems like other framework-agnostic solutions such as ZagJS are also listed, so it should still make the list imo.