### PR TITLE
docs: add solid-jotai to state mgmt list

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ _more coming soon..._
 - [Gstatem](https://github.com/gstatem/gstatem)
 - [Solid Services](https://github.com/exelord/solid-services)
 - [Effector](https://github.com/effector/effector/tree/master/packages/effector-solid)
+- [Solid Jotai](https://github.com/wobsoriano/solid-jotai)
 
 ### Frameworks & Component Libraries
 


### PR DESCRIPTION
Adds [solid-jotai](https://github.com/wobsoriano/solid-jotai) - state management for Solid based on Jotai.