### PR TITLE
Add web components category

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,10 +274,14 @@ _more coming soon..._
 - [Effector](https://github.com/effector/effector/tree/master/packages/effector-solid)
 - [Solid Jotai](https://github.com/wobsoriano/solid-jotai)
 
+### Web Components
+
+- [Solid Element](https://github.com/solidjs/solid/tree/main/packages/solid-element) - Library for authoring web components with SolidJS.
+- [Lume Element](https://github.com/lume/element) - Fast and simple custom elements
+
 ### Frameworks & Component Libraries
 
 - [Solid Blocks](https://atk.github.io/solid-blocks) - UI building blocks for SolidJS.
-- [Lume](https://github.com/lume/element) - Fast and simple custom elements
 - [Solid Headless](https://github.com/LXSMNSYC/solid-headless) - Headless UI for SolidJS
 - [Solid Bootstrap](https://solid-libs.github.io/solid-bootstrap/) - The most popular front-end framework, re-built for SolidJS
 - [Pigment](https://pigment.kobalte.dev/docs/core/overview/introduction) - A design system built with Kobalte and Tailwind CSS

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
   - [SEO](#seo)
   - [Translation](#translation)
   - [State Management](#state-management)
+  - [Web Components](#web-components)
   - [Frameworks & Component Libraries](#frameworks--component-libraries)
   - [Authentication & Authorization](#authentications--authorization)
   - [Helpers(like React hooks, or Vue composables for SolidJS)](#helpers)


### PR DESCRIPTION
It doesn't make sense to put libs like Kobalte and SUID with Lume Elements in the case category. One is a component library, and the other a library for authoring web components. So a bit different purpose?