### PR TITLE
Remove hypetrigger.io from websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ _more coming soon..._
 ### Apps/Websites
 - [ambient-rvx.web.app](https://ambient-rvx.web.app/)
 - [artbyqreature.com](https://artbyqreature.com/)
-- [Hypetrigger](https://hypetrigger.io/)
 
 <!-- ### Enterprise Usage
 - _Coming Soon__ -->


### PR DESCRIPTION
I don't think https://hypetrigger.io/ is using SolidJS
I tried running [this script for detecting solid](https://gist.github.com/thetarnav/1f9d1fe6c2b5a97b10def652400e20a5) and it couldn't.
From the look of html it's using next.js

![image](https://github.com/one-aalam/awesome-solid-js/assets/24491503/a753ebb0-86cd-41ac-85d2-9f0d1a0da581)
