### PR TITLE
Add Made in Solid

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ _more coming soon..._
 - _Coming Soon__ -->
 
 ### Apps/Websites
+- [Made in Solid](https://github.com/solidjs-community/made-in-solid#readme) - SolidJS Portfolio — What have people built with it?
 - [ambient-rvx.web.app](https://ambient-rvx.web.app/)
 - [artbyqreature.com](https://artbyqreature.com/)
 - [Hypetrigger](https://hypetrigger.io/)


### PR DESCRIPTION
I'm maintaining a little resource of projects made with solid: [Made in Solid](https://github.com/solidjs-community/made-in-solid#readme)
It might be easier to just link to this instead of trying to maintain two lists, but idk, maybe it should be the other way around.