### PR TITLE
Fix: solid-chartjs new link

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ _more coming soon..._
 - [Solid Slider](https://github.com/davedbase/solid-slider)
 
 #### Charts
-- [Solid Chart.js](https://github.com/MrFoxPro/solid-chart.js) ([NPM](https://www.npmjs.com/package/solid-chart.js))
+- [Solid Chart.js](https://github.com/s0ftik3/solid-chartjs) ([NPM](https://www.npmjs.com/package/solid-chartjs))
 - [Solid ApexCharts](https://github.com/wobsoriano/solid-apexcharts)
 
 #### Animation


### PR DESCRIPTION
Hi, I realized the chartjs repo is no longer exists. But I found another chartjs port for solidjs to replace the old one.