### PR TITLE
Add @stitchapi/solid

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Re-usable behavioral code (like React hooks, or Vue composables for SolidJS)
 ### Querying/GraphQL
 - [Solid URQL](https://github.com/Acidic9/solid-urql)
 - [TanStack Solid Query](https://tanstack.com/query/v4) ([NPM](https://www.npmjs.com/package/@tanstack/solid-query))
+- [@stitchapi/solid](https://github.com/rejifald/StitchAPI/tree/main/packages/solid) ([NPM](https://www.npmjs.com/package/@stitchapi/solid)) - Streaming-first StitchAPI bindings: typed, validated `createStitch` / `createStitchStream` primitives that reconcile a Solid store as response deltas arrive.
 
 ### Testing
 - [Solid Jest](https://github.com/solidjs/solid-jest)(official)


### PR DESCRIPTION
Adds `@stitchapi/solid` to **Components & Libraries → Querying/GraphQL**, alongside TanStack Solid Query.

Typed, validated SolidJS bindings over a single [StitchAPI](https://stitchapi.dev) definition — `createStitch` / `createStitchStream` primitives that reconcile a Solid `createStore` from the query lifecycle. What makes it different: it's **streaming-first** — `createStitchStream` reconciles each response *delta* into the store as it arrives (SSE / chunked streams), so the UI updates incrementally rather than only on the final response. Input/options accept signals/accessors for fine-grained re-fetch, and an optional TanStack Query `queryOptions` adapter is included.

- Source: https://github.com/rejifald/StitchAPI/tree/main/packages/solid
- npm: https://www.npmjs.com/package/@stitchapi/solid
