### PR TITLE
Add Tura to SolidJS open-source projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Ryan's in-depth streams on all things Solid & reactivity
 ### Open Source
 - [Codeimage.dev](https://github.com/riccardoperra/codeimage) - Create elegant screenshots of your source code. Built with SolidJS
 - [Bloki.app](https://github.com/MrFoxPro/bloki) - Blocks-based collaborative editor
+- [Tura](https://github.com/Tura-AI/tura) - Tura is a local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it. Its desktop GUI is built with SolidJS.
 _more coming soon..._
 
 <!-- ### Commercial Products


### PR DESCRIPTION
## Summary

- Adds Tura to the Open Source section.
- Tura's desktop GUI is built with SolidJS; the app declares `solid-js` and `@solidjs/router` dependencies.
- Keeps the contribution to one README line, matching the existing list format.
- Local README, GitHub code, Issue, and pull-request searches found no existing Tura entry.

## Project

**Tura: 16.7% better performance, 77.5% fewer rounds.**

Tura is a local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it.

- Repository: https://github.com/Tura-AI/tura
- SolidJS implementation evidence: https://github.com/Tura-AI/tura/blob/main/apps/gui/app/package.json
- Benchmark: https://turaai.net/benchmark

## Disclosure

I am affiliated with the Tura project. AI assistance was used to research the target repository, check duplicates, prepare this one-line README change, and draft this pull-request description; I reviewed and verified the final submission.