### PR TITLE
Add ArkEnv to Tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ _more coming soon..._
 ## 🛠️ Tooling
 
 - [bun-plugin-solid](https://github.com/DaniGuardiola/bun-plugin-solid) - A plugin to compile Solid.js with Bun.
+- [ArkEnv](https://github.com/yamcodes/arkenv) - Environment variable validation from editor to runtime, integrates with Solid and SolidStart via its Vite plugin.
 
 ## 📦 Components & Libraries
 


### PR DESCRIPTION
Adds [ArkEnv](https://github.com/yamcodes/arkenv) to the Tooling section.

ArkEnv validates environment variables from editor to runtime. It integrates with Solid and SolidStart through its Vite plugin (`@arkenv/vite-plugin`), and the repo includes a [SolidStart example](https://github.com/yamcodes/arkenv/tree/main/examples/with-solid-start).

Made with [Cursor](https://cursor.com)